### PR TITLE
Support podman and "neutralize" terms

### DIFF
--- a/.github/workflows/build-notconf-base.yml
+++ b/.github/workflows/build-notconf-base.yml
@@ -48,6 +48,5 @@ jobs:
     - name: Store container logs in artifact
       uses: actions/upload-artifact@v3
       with:
-        name: docker-logs
-        path: docker-logs/
-
+        name: container-logs
+        path: container-logs/

--- a/.github/workflows/build-notconf-base.yml
+++ b/.github/workflows/build-notconf-base.yml
@@ -27,7 +27,9 @@ jobs:
       run: make build
 
     - name: Run tests
-      run: make test
+      run: |
+        make test
+        make test-podman-to-docker
 
     - name: Log in to the Container registry
       uses: docker/login-action@v2

--- a/.github/workflows/build-notconf-base.yml
+++ b/.github/workflows/build-notconf-base.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 env:
   IMAGE_PATH: ghcr.io/mzagozen/notconf/
+  CONTAINER_RUNTIME: podman
 
 jobs:
   build:

--- a/.github/workflows/build-notconf-base.yml
+++ b/.github/workflows/build-notconf-base.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Update deps
       run: make clone-deps
 
-    - name: Build docker images
+    - name: Build container images
       run: make build
 
     - name: Run tests
@@ -31,15 +31,15 @@ jobs:
         make test
         make test-podman-to-docker
 
-    - name: Log in to the Container registry
-      uses: docker/login-action@v2
+    - name: Log in to the container registry
+      uses: redhat-actions/podman-login@v1
       if: ${{ github.ref_name == 'main' }}
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Tag and push docker images
+    - name: Tag and push container images
       if: ${{ github.ref_name == 'main' }}
       run: |
         make tag-release

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,14 @@ test-stop: CNT_PREFIX?=test-notconf
 test-stop:
 	$(CONTAINER_RUNTIME) ps -aqf name=$(CNT_PREFIX) | xargs --no-run-if-empty docker rm -f
 
+# This test exports the images we built with Podman to Docker and then runs the
+# test suite in Docker. Obviously both container runtimes must be installed on
+# the machine.
+test-podman-to-docker:
+	podman save $(IMAGE_PATH)notconf:$(DOCKER_TAG) | docker load
+	podman save $(IMAGE_PATH)notconf:$(DOCKER_TAG)-debug | docker load
+	CONTAINER_RUNTIME=docker $(MAKE) test
+
 save-logs: CNT_PREFIX?=test-notconf
 save-logs:
 	mkdir -p docker-logs

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+# Defines the container runtime to use for building images and running tests. We
+# default to "docker" because it works in most environments. Most users will
+# have Docker installed, or use Podman with the "alias docker=podman" set up. In
+# GitHub actions runner VM (ubuntu) both Podman and Docker are installed so we
+# set this variable to "podman" because we want to use it in CI.
+CONTAINER_RUNTIME?=docker
+
 # helper function to turn a string into lower case
 lc = $(subst A,a,$(subst B,b,$(subst C,c,$(subst D,d,$(subst E,e,$(subst F,f,$(subst G,g,$(subst H,h,$(subst I,i,$(subst J,j,$(subst K,k,$(subst L,l,$(subst M,m,$(subst N,n,$(subst O,o,$(subst P,p,$(subst Q,q,$(subst R,r,$(subst S,s,$(subst T,t,$(subst U,u,$(subst V,v,$(subst W,w,$(subst X,x,$(subst Y,y,$(subst Z,z,$1))))))))))))))))))))))))))
 ifneq ($(CI_REGISTRY),)
@@ -20,7 +27,6 @@ ifeq ($(CI_COMMIT_REF_NAME),$(CI_DEFAULT_BRANCH))
 DOCKER_BUILD_CACHE_ARG?=--no-cache
 endif
 endif
-
 
 DOCKER_TAG?=$(PNS)
 
@@ -48,30 +54,39 @@ clone-deps:
 	$(MAKE) clone-or-update REPOSITORY=https://github.com/CESNET/libnetconf2.git BRANCH=$(LIBNETCONF2_TAG)
 	$(MAKE) clone-or-update REPOSITORY=https://github.com/CESNET/netopeer2.git BRANCH=$(NETOPEER2_TAG)
 
+# BuildKit speeds up the image builds by running independent stages in a
+# multi-stage Dockerfile concurrently. BuildKit is a breeze to use with Docker -
+# everything just works automagically when you set the env var. The process is a
+# bit more involved when using Podman so we are currently only using BuildKit on
+# Docker.
 build: export DOCKER_BUILDKIT=1
+# The standardized OCI image spec does not store the healthcheck in image
+# metadata, so there is no support for the HEALTHCHECK directive in the
+# Dockerfile. We can use the "docker" image spec with Podman.
+build: export BUILDAH_FORMAT=docker
 build:
 # We explicitly build the first 'build-tools-source' stage (where the
 # dependencies are installed and source code is pulled), which allows us to
 # control caching of it through the DOCKER_BUILD_CACHE_ARG.
-	docker build --target build-tools-source $(DOCKER_BUILD_CACHE_ARG) .
-	docker build --target notconf-release -t $(IMAGE_PATH)notconf:$(DOCKER_TAG) --build-arg BUILD_TYPE=Release .
-	docker build --target notconf-debug -t $(IMAGE_PATH)notconf:$(DOCKER_TAG)-debug --build-arg BUILD_TYPE=Debug .
+	$(CONTAINER_RUNTIME) build --target build-tools-source $(DOCKER_BUILD_CACHE_ARG) .
+	$(CONTAINER_RUNTIME) build --target notconf-release -t $(IMAGE_PATH)notconf:$(DOCKER_TAG) --build-arg BUILD_TYPE=Release .
+	$(CONTAINER_RUNTIME) build --target notconf-debug -t $(IMAGE_PATH)notconf:$(DOCKER_TAG)-debug --build-arg BUILD_TYPE=Debug .
 
 tag-release:
-	docker tag $(IMAGE_PATH)notconf:$(DOCKER_TAG) $(IMAGE_PATH)notconf:latest
-	docker tag $(IMAGE_PATH)notconf:$(DOCKER_TAG)-debug $(IMAGE_PATH)notconf:debug
+	$(CONTAINER_RUNTIME) tag $(IMAGE_PATH)notconf:$(DOCKER_TAG) $(IMAGE_PATH)notconf:latest
+	$(CONTAINER_RUNTIME) tag $(IMAGE_PATH)notconf:$(DOCKER_TAG)-debug $(IMAGE_PATH)notconf:debug
 
 push-release:
-	docker push $(IMAGE_PATH)notconf:debug
-	docker push $(IMAGE_PATH)notconf:latest
+	$(CONTAINER_RUNTIME) push $(IMAGE_PATH)notconf:debug
+	$(CONTAINER_RUNTIME) push $(IMAGE_PATH)notconf:latest
 
 push:
-	docker push $(IMAGE_PATH)notconf:$(DOCKER_TAG)
-	docker push $(IMAGE_PATH)notconf:$(DOCKER_TAG)-debug
+	$(CONTAINER_RUNTIME) push $(IMAGE_PATH)notconf:$(DOCKER_TAG)
+	$(CONTAINER_RUNTIME) push $(IMAGE_PATH)notconf:$(DOCKER_TAG)-debug
 
 test: export CNT_PREFIX=test-notconf-$(PNS)
 test:
-	-docker rm -f $(CNT_PREFIX)
+	-$(CONTAINER_RUNTIME) rm -f $(CNT_PREFIX)
 # Usually we would start the notconf container with the desired YANG module
 # (located on host) mounted to /yang-modules (in container). When the test
 # itself is executed in a (CI runner) container bind mounting a path won't work
@@ -79,27 +94,27 @@ test:
 # workaround we first create the container and then copy the YANG module to the
 # target location.
 #	docker run -d --name $(CNT_PREFIX) -v $$(pwd)/test:/yang-modules $(IMAGE_PATH)notconf:$(DOCKER_TAG)
-	docker create --name $(CNT_PREFIX) $(IMAGE_PATH)notconf:$(DOCKER_TAG)
-	docker cp test/test.yang $(CNT_PREFIX):/yang-modules/
-	docker cp test/test.xml $(CNT_PREFIX):/yang-modules/
-	docker start $(CNT_PREFIX)
+	$(CONTAINER_RUNTIME) create --name $(CNT_PREFIX) $(IMAGE_PATH)notconf:$(DOCKER_TAG)
+	$(CONTAINER_RUNTIME) cp test/test.yang $(CNT_PREFIX):/yang-modules/
+	$(CONTAINER_RUNTIME) cp test/test.xml $(CNT_PREFIX):/yang-modules/
+	$(CONTAINER_RUNTIME) start $(CNT_PREFIX)
 	$(MAKE) wait-healthy
-	docker run -i --rm --network container:$(CNT_PREFIX) $(IMAGE_PATH)notconf:$(DOCKER_TAG)-debug netconf-console2 --port 830 --get-config -x /bob/startup | grep Robert
-	docker run -i --rm --network container:$(CNT_PREFIX) $(IMAGE_PATH)notconf:$(DOCKER_TAG)-debug netconf-console2 --port 830 --ns test=urn:notconf:test --set /test:bob/test:bert=Robert
-	docker run -i --rm --network container:$(CNT_PREFIX) $(IMAGE_PATH)notconf:$(DOCKER_TAG)-debug netconf-console2 --port 830 --get-config -x /bob/bert | grep Robert
+	$(CONTAINER_RUNTIME) run -i --rm --network container:$(CNT_PREFIX) $(IMAGE_PATH)notconf:$(DOCKER_TAG)-debug netconf-console2 --port 830 --get-config -x /bob/startup | grep Robert
+	$(CONTAINER_RUNTIME) run -i --rm --network container:$(CNT_PREFIX) $(IMAGE_PATH)notconf:$(DOCKER_TAG)-debug netconf-console2 --port 830 --ns test=urn:notconf:test --set /test:bob/test:bert=Robert
+	$(CONTAINER_RUNTIME) run -i --rm --network container:$(CNT_PREFIX) $(IMAGE_PATH)notconf:$(DOCKER_TAG)-debug netconf-console2 --port 830 --get-config -x /bob/bert | grep Robert
 	$(MAKE) save-logs
 	$(MAKE) test-stop
 
 test-stop: CNT_PREFIX?=test-notconf
 test-stop:
-	docker ps -aqf name=$(CNT_PREFIX) | xargs --no-run-if-empty docker rm -f
+	$(CONTAINER_RUNTIME) ps -aqf name=$(CNT_PREFIX) | xargs --no-run-if-empty docker rm -f
 
 save-logs: CNT_PREFIX?=test-notconf
 save-logs:
 	mkdir -p docker-logs
-	@for c in $$(docker ps -af name=$(CNT_PREFIX) --format '{{.Names}}'); do \
+	@for c in $$($(CONTAINER_RUNTIME) ps -af name=$(CNT_PREFIX) --format '{{.Names}}'); do \
 		echo "== Collecting logs from $${c}"; \
-		docker logs $${c} > docker-logs/$${c} 2>&1; \
+		$(CONTAINER_RUNTIME) logs $${c} > docker-logs/$${c} 2>&1; \
 	done
 
 SHELL=/bin/bash
@@ -107,12 +122,12 @@ SHELL=/bin/bash
 wait-healthy:
 	@echo "Waiting (up to 900 seconds) for containers with prefix $(CNT_PREFIX) to become healthy"
 	@OLD_COUNT=0; for I in $$(seq 1 900); do \
-		COUNT=$$(docker ps -f name=$(CNT_PREFIX) | egrep "(unhealthy|health: starting)" | wc -l); \
+		COUNT=$$($(CONTAINER_RUNTIME) ps -f name=$(CNT_PREFIX) | egrep "(unhealthy|health: starting)" | wc -l); \
 		if [ $$COUNT -gt 0 ]; then  \
 			if [ $$OLD_COUNT -ne $$COUNT ];\
 			then \
 				echo -e "\e[31m===  $${SECONDS}s elapsed - Found unhealthy/starting ($${COUNT}) containers";\
-				docker ps -f name=$(CNT_PREFIX) | egrep "(unhealthy|health: starting)" | awk '{ print $$(NF) }';\
+				$(CONTAINER_RUNTIME) ps -f name=$(CNT_PREFIX) | egrep "(unhealthy|health: starting)" | awk '{ print $$(NF) }';\
 				echo -e "Checking again every 1 second, no more messages until changes detected\\e[0m"; \
 			fi;\
 			sleep 1; \
@@ -124,6 +139,6 @@ wait-healthy:
 		fi ;\
 	done; \
 	echo -e "\e[31m===  $${SECONDS}s elapsed - Found unhealthy/starting ($${COUNT}) containers";\
-	docker ps -f name=$(CNT_PREFIX) | egrep "(unhealthy|health: starting)" | awk '{ print $$(NF) }';\
+	$(CONTAINER_RUNTIME) ps -f name=$(CNT_PREFIX) | egrep "(unhealthy|health: starting)" | awk '{ print $$(NF) }';\
 	echo -e "\e[0m"; \
 	exit 1

--- a/Makefile
+++ b/Makefile
@@ -119,10 +119,10 @@ test-podman-to-docker:
 
 save-logs: CNT_PREFIX?=test-notconf
 save-logs:
-	mkdir -p docker-logs
+	mkdir -p container-logs
 	@for c in $$($(CONTAINER_RUNTIME) ps -af name=$(CNT_PREFIX) --format '{{.Names}}'); do \
 		echo "== Collecting logs from $${c}"; \
-		$(CONTAINER_RUNTIME) logs $${c} > docker-logs/$${c} 2>&1; \
+		$(CONTAINER_RUNTIME) logs $${c} > container-logs/$${c} 2>&1; \
 	done
 
 SHELL=/bin/bash

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ then copies the results to a clean image.
 ❯ docker build -f Dockerfile.yang -t notconf-test --build-arg COMPOSE_PATH=test .
 Sending build context to Docker daemon
 Step 1/9 : ARG IMAGE_PATH
-Step 2/9 : ARG DOCKER_TAG=latest
-Step 3/9 : FROM ${IMAGE_PATH}notconf:${DOCKER_TAG} AS notconf-install
+Step 2/9 : ARG IMAGE_TAG=latest
+Step 3/9 : FROM ${IMAGE_PATH}notconf:${IMAGE_TAG} AS notconf-install
  ---> 62b1b5b48905
 Step 4/9 : ARG COMPOSE_PATH
  ---> Running in 9cf6b8d26422
@@ -104,7 +104,7 @@ Successfully tagged notconf-test:latest
 
 Note: `Dockerfile.yang` has two additional optional build arguments:
 - `IMAGE_PATH`: prefix to the base notconf docker image, like `registry.example.org/notconf`, defaults to empty string
-- `DOCKER_TAG`: suffix to the base notconf docker image, defaults to `latest`
+- `IMAGE_TAG`: suffix to the base notconf docker image, defaults to `latest`
 
 ### Compose a custom notconf image with vendor YANG modules
 

--- a/README.md
+++ b/README.md
@@ -17,16 +17,16 @@ with creating a complete virtual machine (router).
 
 ### Prerequisites
 
-For running the container from a pre-built image the only prerequisite is docker
-or some other container runtime. Building the base and custom images further
-requires make, git and xmlstarlet and optionally netconf-console2 for NETCONF
-operations testing. netconf-console2 is also installed in the notconf:debug
-image for convenience. For an definitive list check the GitHub action workflow
-for the `build-notconf-base`.
+For running the container from a pre-built image the only prerequisite is Docker
+or some other container runtime like Podman. Building the base and custom images
+further requires make, git and xmlstarlet and optionally netconf-console2 for
+NETCONF operations testing. netconf-console2 is also installed in the
+notconf:debug image for convenience. For an definitive list check the GitHub
+action workflow for the `build-notconf-base`.
 
 ### Start a container with custom YANG modules
 
-The base docker image `notconf:latest` contains the Netopeer2 installation with
+The base container image `notconf:latest` contains the Netopeer2 installation with
 all of its runtime dependencies. The set of YANG modules included in the NETCONF
 server is the bare minimum to make Netopeer2 work. This is enough for any
 NETCONF client to establish a NETCONF session, but not much else. You will most
@@ -103,8 +103,8 @@ Successfully tagged notconf-test:latest
 ```
 
 Note: `Dockerfile.yang` has two additional optional build arguments:
-- `IMAGE_PATH`: prefix to the base notconf docker image, like `registry.example.org/notconf`, defaults to empty string
-- `IMAGE_TAG`: suffix to the base notconf docker image, defaults to `latest`
+- `IMAGE_PATH`: prefix to the base notconf container image, like `ghcr.io/mzagozen/notconf/notconf`, defaults to empty string
+- `IMAGE_TAG`: suffix to the base notconf container image, defaults to `latest`
 
 ### Compose a custom notconf image with vendor YANG modules
 


### PR DESCRIPTION
[Podman] is an alternative container engine to Docker. The user interface is compatible with Docker so for the most part supporting Podman does not require changing existing scripts, just `alias docker=podman`. In the GitHub Actions runners both Docker and Podman are installed so I added a `CONTAINER_RUNTIME` variable that allows me to use Podman in CI.

All other changes in this MR are just renaming terms from *docker* to a more neutral *container*.

[Podman]: https://podman.io/