### PR TITLE
Podman journald logs?!

### DIFF
--- a/.github/workflows/build-notconf-base.yml
+++ b/.github/workflows/build-notconf-base.yml
@@ -12,6 +12,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Show podman info
+      run: |
+        podman info --format '{{ .Host.LogDriver }}'
+        podman create --help | grep log-driver
+        podman info
+
     - uses: actions/checkout@v3
 
     - name: Cache deps

--- a/Makefile
+++ b/Makefile
@@ -121,10 +121,10 @@ save-logs: CNT_PREFIX?=test-notconf
 save-logs:
 	mkdir -p container-logs
 	@for c in $$($(CONTAINER_RUNTIME) ps -af name=$(CNT_PREFIX) --format '{{.Names}}'); do \
-		echo "== Collecting logs from $${c}"; \
-		$(CONTAINER_RUNTIME) logs --timestamps $${c} > container-logs/$${c}.log 2>&1; \
-		$(CONTAINER_RUNTIME) inspect $${c} > container-logs/$${c}_inspect.log; \
-		$(CONTAINER_RUNTIME) run -i --rm --network container:$${c} $(IMAGE_PATH)notconf:$(IMAGE_TAG)-debug netconf-console2 --port 830 --hello > container-logs/$${c}_netconf.log || true; \
+		echo "== Collecting $(CONTAINER_RUNTIME) logs from $${c}"; \
+		$(CONTAINER_RUNTIME) logs --timestamps $${c} > container-logs/$(CONTAINER_RUNTIME)_$${c}.log 2>&1; \
+		$(CONTAINER_RUNTIME) inspect $${c} > container-logs/$(CONTAINER_RUNTIME)_$${c}_inspect.log; \
+		$(CONTAINER_RUNTIME) run -i --rm --network container:$${c} $(IMAGE_PATH)notconf:$(IMAGE_TAG)-debug netconf-console2 --port 830 --hello > container-logs/$(CONTAINER_RUNTIME)_$${c}_netconf.log || true; \
 	done
 
 SHELL=/bin/bash

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ test:
 # workaround we first create the container and then copy the YANG module to the
 # target location. The following command would probably work on your local machine:
 #	$(CONTAINER_RUNTIME) run -d --name $(CNT_PREFIX) -v $$(pwd)/test:/yang-modules $(IMAGE_PATH)notconf:$(IMAGE_TAG)
-	$(CONTAINER_RUNTIME) create --name $(CNT_PREFIX) $(IMAGE_PATH)notconf:$(IMAGE_TAG)
+	$(CONTAINER_RUNTIME) create --log-driver json-file --name $(CNT_PREFIX) $(IMAGE_PATH)notconf:$(IMAGE_TAG)
 	$(CONTAINER_RUNTIME) cp test/test.yang $(CNT_PREFIX):/yang-modules/
 	$(CONTAINER_RUNTIME) cp test/test.xml $(CNT_PREFIX):/yang-modules/
 	$(CONTAINER_RUNTIME) start $(CNT_PREFIX)

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ save-logs:
 	@for c in $$($(CONTAINER_RUNTIME) ps -af name=$(CNT_PREFIX) --format '{{.Names}}'); do \
 		echo "== Collecting logs from $${c}"; \
 		$(CONTAINER_RUNTIME) logs --timestamps $${c} > container-logs/$${c}.log 2>&1; \
+		$(CONTAINER_RUNTIME) run -i --rm --network container:$${c} $(IMAGE_PATH)notconf:$(IMAGE_TAG)-debug netconf-console2 --port 830 --hello > container-logs/$${c}_netconf.log || true; \
 	done
 
 SHELL=/bin/bash

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ save-logs:
 	@for c in $$($(CONTAINER_RUNTIME) ps -af name=$(CNT_PREFIX) --format '{{.Names}}'); do \
 		echo "== Collecting logs from $${c}"; \
 		$(CONTAINER_RUNTIME) logs --timestamps $${c} > container-logs/$${c}.log 2>&1; \
+		$(CONTAINER_RUNTIME) inspect $${c} > container-logs/$${c}_inspect.log; \
 		$(CONTAINER_RUNTIME) run -i --rm --network container:$${c} $(IMAGE_PATH)notconf:$(IMAGE_TAG)-debug netconf-console2 --port 830 --hello > container-logs/$${c}_netconf.log || true; \
 	done
 


### PR DESCRIPTION
Podman in GitHub CI defaults to using *journald* as the log driver for container logs. This can cause problems if *journald* is configured with the (default) burst rate limits - messages are lost. On my machine however the default log drive is *json-file*. To ensure no messages are lost we explicitly set that when creating the container now.