### PR TITLE
Install all sysrepo modules in one batch 🚀

### DIFF
--- a/fixups/yang/vendor/nokia/Makefile
+++ b/fixups/yang/vendor/nokia/Makefile
@@ -18,33 +18,8 @@ all: $(YANGS_SUBMODULE:$(YANG_PATH)/nokia-submodule/%.yang=$(COMPOSE_PATH)/%.yan
 vpath %.yang $(YANG_PATH)/nokia-submodule
 vpath %.yang $(YANG_PATH)
 
-# This is the first stage of preparing the nokia modules where we strip the
-# "incorrect" extension usage statement and collect all processed YANG modules
-# to a single directory. The next stage then has access to everything.
-$(COMPOSE_PATH)/strip/%.yang: %.yang
-	@mkdir -p $(COMPOSE_PATH)/strip
-# The extension instance appears in the 'meta-stms' header section in the YANG
-# module - just before the 'organization' statement. libyang thinks that is not
-# allowed, but looking at the YANG ABNF grammar we're not so sure. Extension
-# statement instances are parsed as 'unknown-statement' which can appear
-# anywhere! Let's strip the statement until libyang is fixed.
-	sed -e '/sros-ext:sros-major-release/d' $< > $@
-
-$(COMPOSE_PATH)/%.yang: $(COMPOSE_PATH)/strip/%.yang
+$(COMPOSE_PATH)/%.yang: %.yang
 	cp $< $@
-	@mkdir -p $(COMPOSE_PATH)/install
-# Mark the module for installation if it contains at least one data node. This
-# saves time by skipping installation of nodes that only contain groupings or
-# typedefs. Store pyang output in a temporary variable to ensure the YANG module
-# gets marked for installation in case pyang (or xmlstarlet) fails to process
-# the file.
-	@if ! head -n1 $@ | grep -e '^submodule'; then \
-		top_level_statements=$$(pyang --ignore-errors -f yin $@ -p $(COMPOSE_PATH)/strip | xmlstarlet sel -t -m '_:module/*' -v 'name()' -n); \
-		if [ $$? -eq 0 ]; then echo $${top_level_statements} | grep -F -e container -e leaf -e leaf-list -e list -e choice -e anydata -e anyxml -e uses -e rpc -e action -e notification -e augment -e identity && touch $(COMPOSE_PATH)/install/$(@F); \
-		else \
-			touch $(COMPOSE_PATH)/install/$(@F); \
-		fi \
-	fi || true
 
 .PHONY: all test test-sysrepo test-netopeer
 

--- a/install-yang-modules.sh
+++ b/install-yang-modules.sh
@@ -5,11 +5,27 @@ else MODULES=$(ls ${YANG_MODULES_DIR}/*.yang); fi
 
 n=0
 total=$(echo "${MODULES}" | wc -l)
+declare -a install_modules=()
+
 # Stop installing modules on errors
 set -e
+
+# Skip submodules as they will automatically be installed with their parent
 for f in ${MODULES}; do
 	n=$((n+1))
 	if head -n1 $f | grep ^submodule > /dev/null 2>&1; then echo "[$n/$total] Skipping submodule $f"; continue; fi
-	echo "[$n/$total] Installing module $f"
-	time sysrepoctl --search-dirs ${YANG_MODULES_DIR} --install $f -v3
+	echo "[$n/$total] Preparing to install module $f"
+	install_modules+=($f)
 done
+
+if [ ${#install_modules[@]} -eq 0 ]; then
+	echo "No modules to install"
+	exit 0
+fi
+
+# Add --install flag to each module name
+install_modules=( "${install_modules[@]/#/--install }" )
+
+# Install all modules in a single batch (recent-ish feature
+# https://github.com/CESNET/netopeer2/issues/1337#issuecomment-1403225980)
+time sysrepoctl --search-dirs ${YANG_MODULES_DIR} ${install_modules[@]} -v3


### PR DESCRIPTION
A recent version of sysrepo supports installing modules in a single batch instead of having to install individual modules, which *significantly* improves the image build times.  For example the IOS XR device model for 7.x consists of around 1700 YANG modules. Installing each module individually took around 3 hours, now it takes 10 seconds🤯.