### PR TITLE
Listen on IPv4, IPv6 (dual-stack)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,9 @@ RUN cmake -B build -D CMAKE_BUILD_TYPE:String=${BUILD_TYPE} -D BUILD_TESTING=OFF
   make -C build install
 
 WORKDIR /src/nghttp2-asio
+# Drop AI_ADDRCONFIG: getaddrinfo("::") fails with only loopback IPv6 (::1),
+# crashing rousette on bind. AI_PASSIVE alone lets it bind "::" reliably.
+RUN sed -i 's/tcp::resolver::query query(address, port);/tcp::resolver::query query(address, port, tcp::resolver::query::passive);/' lib/asio_server.cc
 RUN cmake -B build -D CMAKE_BUILD_TYPE:String=${BUILD_TYPE} && \
   make -C build -j && \
   make -C build install
@@ -75,9 +78,8 @@ RUN cmake -B build -D CMAKE_BUILD_TYPE:String=${BUILD_TYPE} -D BUILD_TZ_LIB=ON &
   make -C build install
 
 WORKDIR /src/rousette
-# Apply IPv4 patch to support IPv4-only environments
-RUN sed -i 's/"::1"/"0.0.0.0"/' src/restconf/main.cpp && \
-  sed -i '/auto server = rousette::restconf::Server/i\    // Listen on all interfaces (0.0.0.0) to support both IPv4 and IPv6\n    // This works even if IPv6 is disabled in the container' src/restconf/main.cpp
+# Bind "::" (dual-stack) instead of upstream "::1" (loopback only)
+RUN sed -i 's/"::1"/"::"/' src/restconf/main.cpp
 RUN cmake -B build -D CMAKE_BUILD_TYPE:String=${BUILD_TYPE} -D BUILD_TESTING=OFF && \
   make -C build -j && \
   make -C build install

--- a/README.md
+++ b/README.md
@@ -312,6 +312,13 @@ the HTTP/2 protocol. This setup allows clients to connect using standard HTTP/1.
 port 80, while maintaining HTTP/2 communication with rousette. Authentication uses the
 same credentials as NETCONF (default: admin/admin).
 
+### IPv4/IPv6 dual-stack
+
+netopeer2 and rousette both bind the IPv6 wildcard `::`. This will bind the
+listening socket on both IPv4 and IPv6 on most Linux systems. The only
+unsupported case is if IPv6 was altogether disabled in the kernel
+(`CONFIG_IPV6=n`) or disabled at boot (`ipv6.disable=1`).
+
 ### Debugging sysrepo, Netopeer2 and rousette
 
 All the heavy lifting of providing NETCONF and RESTCONF servers is done by Netopeer2,

--- a/admin.xml
+++ b/admin.xml
@@ -4,6 +4,10 @@
       <endpoint>
         <name>default-ssh</name>
         <ssh>
+          <tcp-server-parameters>
+            <!-- IPv6 wildcard (dual-stack); overrides merge_config.sh's 0.0.0.0 -->
+            <local-address>::</local-address>
+          </tcp-server-parameters>
           <ssh-server-parameters>
             <client-authentication>
               <users>


### PR DESCRIPTION
Bind netopeer2 and rousette to "::":
- admin.xml: default-ssh local-address -> "::"
- Dockerfile: rousette "::1" -> "::", "all addresses" are semantically different from "loopback", but since we're running in a container it is fine ...
- Dockerfile: nghttp2-asio drops AI_ADDRCONFIG so getaddrinfo("::") works with loopback-only IPv6 (else rousette crashes on bind)